### PR TITLE
Ignore jwtproxy pods in codeready pv backup

### DIFF
--- a/image/tools/lib/component/codeready_pv.sh
+++ b/image/tools/lib/component/codeready_pv.sh
@@ -11,7 +11,7 @@ function component_dump_data {
     if [[ -z "${PRODUCT_NAMESPACE:-}" ]]; then
         PRODUCT_NAMESPACE="${PRODUCT_NAMESPACE_PREFIX}codeready"
     fi
-    local pods="$(oc get pods -n ${PRODUCT_NAMESPACE} --no-headers=true -l "che.workspace_id" | awk '{print $1}')"
+    local pods="$(oc get pods -n ${PRODUCT_NAMESPACE} --no-headers=true -l "che.workspace_id,che.original_name notin (che-jwtproxy)" | awk '{print $1}')"
     if [ "${#pods}" -eq "0" ]; then
         echo "=>> No workspaces found to backup"
         exit 0


### PR DESCRIPTION
## Description
With the upgrade to use CodeReady 2.0.0 GA, created workspaces also create a `che-jwtproxy` pod causing the backup procedure to fail due to these pods do not have the `/projects` directory.

I don't think these pods are necessary for the backups, so just ignoring them in the pod selector for backups